### PR TITLE
Resolve RegistrationAmf3gppAccess failure and missing header validation

### DIFF
--- a/producer/ue_context_management.go
+++ b/producer/ue_context_management.go
@@ -219,13 +219,18 @@ func RegistrationAmf3gppAccessProcedure(registerRequest models.Amf3GppAccessRegi
 	resp, err := clientAPI.AMF3GPPAccessRegistrationDocumentApi.CreateAmfContext3gpp(context.Background(),
 		ueID, &createAmfContext3gppParamOpts)
 	if err != nil {
-		logger.UecmLog.Errorln("CreateAmfContext3gpp error : ", err)
-		problemDetails = &models.ProblemDetails{
-			Status: int32(resp.StatusCode),
-			Cause:  err.(openapi.GenericOpenAPIError).Model().(models.ProblemDetails).Cause,
-			Detail: err.Error(),
+		// Explicitly check if the error is actually a 201 Created success
+		if resp != nil && resp.StatusCode == 201 {
+			logger.UecmLog.Infoln("UDR returned 201 Created")
+		} else {
+			logger.UecmLog.Errorln("CreateAmfContext3gpp error : ", err)
+			problemDetails = &models.ProblemDetails{
+				Status: int32(resp.StatusCode),
+				Cause:  err.(openapi.GenericOpenAPIError).Model().(models.ProblemDetails).Cause,
+				Detail: err.Error(),
+			}
+			return nil, nil, problemDetails
 		}
-		return nil, nil, problemDetails
 	}
 	defer func() {
 		if rspCloseErr := resp.Body.Close(); rspCloseErr != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**:
This PR addresses a failure in the RegistrationAmf3gppAccess (Nudm_UECM) service where the Location header was missing from the response sent to the AMF. Without this fix, the UDM aborts the processing of successful UDR creations early, failing to return standard HTTP headers required by the 3GPP specification. This causes conformance tests to fail.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#24](https://github.com/5GC-DEV/udm-cdac/issues/24)

**Test Report Added?**:
> /kind TESTED


**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
NA

**Special notes for your reviewer**:
NIL
