### PR TITLE
Fix: UDM returns 500 Internal Server Error instead of expected 201 for SMF Registration Request

### DIFF
--- a/producer/ue_context_management.go
+++ b/producer/ue_context_management.go
@@ -606,10 +606,8 @@ func HandleRegistrationSmfRegistrationsRequest(request *httpwrapper.Request) *ht
 func RegistrationSmfRegistrationsProcedure(request *models.SmfRegistration, ueID string, pduSessionID string) (
 	header http.Header, response *models.SmfRegistration, problemDetails *models.ProblemDetails,
 ) {
-
 	contextExisted := !udmContext.UDM_Self().UdmSmfRegContextNotExists(ueID)
 	udmContext.UDM_Self().CreateSmfRegContext(ueID, pduSessionID)
-
 	pduID64, err := strconv.ParseInt(pduSessionID, 10, 32)
 	if err != nil {
 		logger.UecmLog.Errorln(err.Error())
@@ -617,8 +615,7 @@ func RegistrationSmfRegistrationsProcedure(request *models.SmfRegistration, ueID
 	pduID32 := int32(pduID64)
 
 	var createSmfContextNon3gppParamOpts Nudr_DataRepository.CreateSmfContextNon3gppParamOpts
-	optInterface := optional.NewInterface(*request)
-	createSmfContextNon3gppParamOpts.SmfRegistration = optInterface
+	createSmfContextNon3gppParamOpts.SmfRegistration = optional.NewInterface(*request)
 
 	clientAPI, err := createUDMClientToUDR(ueID)
 	if err != nil {

--- a/producer/ue_context_management.go
+++ b/producer/ue_context_management.go
@@ -606,11 +606,9 @@ func HandleRegistrationSmfRegistrationsRequest(request *httpwrapper.Request) *ht
 func RegistrationSmfRegistrationsProcedure(request *models.SmfRegistration, ueID string, pduSessionID string) (
 	header http.Header, response *models.SmfRegistration, problemDetails *models.ProblemDetails,
 ) {
-	contextExisted := false
+
+	contextExisted := !udmContext.UDM_Self().UdmSmfRegContextNotExists(ueID)
 	udmContext.UDM_Self().CreateSmfRegContext(ueID, pduSessionID)
-	if !udmContext.UDM_Self().UdmSmfRegContextNotExists(ueID) {
-		contextExisted = true
-	}
 
 	pduID64, err := strconv.ParseInt(pduSessionID, 10, 32)
 	if err != nil {

--- a/producer/ue_context_management.go
+++ b/producer/ue_context_management.go
@@ -619,7 +619,7 @@ func RegistrationSmfRegistrationsProcedure(request *models.SmfRegistration, ueID
 	pduID32 := int32(pduID64)
 
 	var createSmfContextNon3gppParamOpts Nudr_DataRepository.CreateSmfContextNon3gppParamOpts
-	optInterface := optional.NewInterface(request)
+	optInterface := optional.NewInterface(*request)
 	createSmfContextNon3gppParamOpts.SmfRegistration = optInterface
 
 	clientAPI, err := createUDMClientToUDR(ueID)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind bug fix


**What this PR does / why we need it**:
During execution of the SMF Registration Request for 3GPP Access test case, the UDM is expected to respond with 201 Created, as specified in 3GPP TS 29.503.
However, the current core implementation returns 500 Internal Server Error, which causes the test to fail.
This PR fixes the issue and ensures that the UDM responds with the correct 201 Created status code as per the specification.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #26

**Test Report Added?**:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
