### PR TITLE
Fix: Nudm_UECM roaming authorization, status code mapping, and mandatory 3GPP error headers.

### DIFF
--- a/producer/ue_context_management.go
+++ b/producer/ue_context_management.go
@@ -18,6 +18,7 @@ import (
 	"github.com/antihax/optional"
 	"github.com/omec-project/udm/consumer"
 	udmContext "github.com/omec-project/udm/context"
+	"github.com/omec-project/udm/factory"
 	"github.com/omec-project/udm/logger"
 	stats "github.com/omec-project/udm/metrics"
 	"github.com/omec-project/udm/producer/callback"
@@ -581,58 +582,139 @@ func DeregistrationSmfRegistrationsProcedure(ueID string, pduSessionID string) (
 	return nil
 }
 
-// HandleRegistrationSmfRegistrationsRequest SmfRegistrations
 func HandleRegistrationSmfRegistrationsRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.UecmLog.Infoln("handle RegistrationSmfRegistrations")
 	registerRequest := request.Body.(models.SmfRegistration)
 	ueID := request.Params["ueId"]
 	pduSessionID := request.Params["pduSessionId"]
+
 	header, response, problemDetails := RegistrationSmfRegistrationsProcedure(&registerRequest, ueID, pduSessionID)
+
+	if problemDetails != nil {
+		// Proper 3GPP Content-Type for Errors (TS 29.571 Section 5.2.2)
+		errHeader := make(http.Header)
+		errHeader.Set("Content-Type", "application/problem+json")
+		return httpwrapper.NewResponse(int(problemDetails.Status), errHeader, problemDetails)
+	}
+
 	if response != nil {
 		stats.IncrementUdmUeContextManagementStats("create", "smf-registrations", "SUCCESS")
-		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusCreated, header, response)
-	} else if problemDetails != nil {
-		stats.IncrementUdmUeContextManagementStats("create", "smf-registrations", "FAILURE")
-		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
-	} else {
-		stats.IncrementUdmUeContextManagementStats("create", "smf-registrations", "SUCCESS")
-		// all nil
-		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
+
+	stats.IncrementUdmUeContextManagementStats("create", "smf-registrations", "SUCCESS")
+	return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 }
 
-// RegistrationSmfRegistrationsProcedure SmfRegistrationsProcedure
+// RegistrationSmfRegistrationsProcedure
 func RegistrationSmfRegistrationsProcedure(request *models.SmfRegistration, ueID string, pduSessionID string) (
 	header http.Header, response *models.SmfRegistration, problemDetails *models.ProblemDetails,
 ) {
+	// Maintain local UDM state
 	contextExisted := !udmContext.UDM_Self().UdmSmfRegContextNotExists(ueID)
 	udmContext.UDM_Self().CreateSmfRegContext(ueID, pduSessionID)
-	pduID64, err := strconv.ParseInt(pduSessionID, 10, 32)
-	if err != nil {
-		logger.UecmLog.Errorln(err.Error())
-	}
-	pduID32 := int32(pduID64)
 
-	var createSmfContextNon3gppParamOpts Nudr_DataRepository.CreateSmfContextNon3gppParamOpts
-	createSmfContextNon3gppParamOpts.SmfRegistration = optional.NewInterface(*request)
-
+	// Setup UDR Client
 	clientAPI, err := createUDMClientToUDR(ueID)
 	if err != nil {
 		return nil, nil, util.ProblemDetailsSystemFailure(err.Error())
 	}
 
-	resp, err := clientAPI.SMFRegistrationDocumentApi.CreateSmfContextNon3gpp(context.Background(), ueID,
-		pduID32, &createSmfContextNon3gppParamOpts)
-	if err != nil {
-		problemDetails.Cause = err.(openapi.GenericOpenAPIError).Model().(models.ProblemDetails).Cause
-		problemDetails = &models.ProblemDetails{
-			Status: int32(resp.StatusCode),
-			Cause:  err.(openapi.GenericOpenAPIError).Model().(models.ProblemDetails).Cause,
-			Detail: err.Error(),
+	// The UDM must authorize the request based on subscription data presence and access barring.
+	var servingPlmnStr string
+	isRoaming := true // Default to roaming unless found in Home Support List
+	if request.PlmnId != nil {
+		servingPlmnStr = request.PlmnId.Mcc + request.PlmnId.Mnc
+		// Determine Roaming Status by comparing Serving PLMN with Home PLMN Support List
+		for _, homePlmn := range factory.UdmConfig.Configuration.PlmnSupportList {
+			if request.PlmnId.Mcc == homePlmn.Mcc && request.PlmnId.Mnc == homePlmn.Mnc {
+				isRoaming = false
+				break
+			}
 		}
-		return nil, nil, problemDetails
 	}
+
+	// Fetch Subscription Data for the Serving PLMN
+	amData, resp, errQuery := clientAPI.AccessAndMobilitySubscriptionDataDocumentApi.
+		QueryAmData(context.Background(), ueID, servingPlmnStr, nil)
+
+	if errQuery != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			if isRoaming {
+				return nil, nil, &models.ProblemDetails{
+					Status: http.StatusForbidden,
+					Cause:  "ROAMING_NOT_ALLOWED",
+					Detail: "No roaming profile found for this VPLMN",
+				}
+			}
+			// If not roaming, data not found
+			return nil, nil, &models.ProblemDetails{
+				Status: http.StatusNotFound,
+				Cause:  "USER_NOT_FOUND",
+			}
+		}
+	} else if resp.StatusCode == http.StatusOK {
+		// Check ODB for Roaming
+		odb := string(amData.OdbPacketServices)
+		if odb != "" && (odb == "ALL_PACKET_SERVICES" || odb == "ROAMER_ACCESS_VPLMN_AP") {
+			return nil, nil, &models.ProblemDetails{
+				Status: http.StatusForbidden,
+				Cause:  "ROAMING_NOT_ALLOWED",
+				Detail: "Roaming is barred by operator determined barring rules",
+			}
+		}
+		/*
+		* TODO: IMPLEMENT FULL ROAMING AUTHORIZATION PROCEDURE
+		* ----------------------------------------------------
+		* Currently, this Private 5G implementation only checks for profile existence and ODB.
+		*
+		* If public roaming is enabled in the future, the following procedure must be implemented:
+		* 1. Evaluate 'RoamingRestrictions' object within 'amData' (AccessAndMobilitySubscriptionData).
+		* 2. Check if the current VPLMN is in the 'ForbiddenAreas' list.
+		* 3. Verify 'CoreNetworkTypeRestrictions' (Ensuring UE is allowed to use 5GC in this VPLMN).
+		* 4. If any restriction matches, return 403 Forbidden with Cause "ROAMING_NOT_ALLOWED".
+		*
+		* References:
+		* - 3GPP TS 23.501 Section 5.3.4.1 (Mobility Restrictions)
+		* - 3GPP TS 29.503 Section 5.3.2.2.2 (SMF Registration Authorization)
+		* - 3GPP TS 29.503 Section 6.2.3.5.1 (Resource Definition)
+		 */
+	}
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+	// Proceed with Registration in UDR if authorized
+	pduID64, errParse := strconv.ParseInt(pduSessionID, 10, 32)
+	if errParse != nil {
+		logger.UecmLog.Errorf("Invalid PDU Session ID [%s]: %v", pduSessionID, errParse)
+		return nil, nil, &models.ProblemDetails{
+			Status: http.StatusBadRequest,
+			Cause:  "INVALID_PDU_SESSION_ID",
+			Detail: "The PDU Session ID provided is not a valid integer",
+		}
+	}
+
+	pduID32 := int32(pduID64) // Convert ID type
+	var createSmfContextNon3gppParamOpts Nudr_DataRepository.CreateSmfContextNon3gppParamOpts
+	createSmfContextNon3gppParamOpts.SmfRegistration = optional.NewInterface(*request)
+	// Create SMF context in UDR
+	resp, err = clientAPI.SMFRegistrationDocumentApi.CreateSmfContextNon3gpp(context.Background(), ueID, pduID32, &createSmfContextNon3gppParamOpts)
+	if err != nil {
+		if resp != nil && (resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated) {
+			logger.UecmLog.Debugln("UDR SMF Registration success")
+		} else {
+			problemDetails = &models.ProblemDetails{Status: http.StatusInternalServerError} // Default error
+			if apiErr, ok := err.(openapi.GenericOpenAPIError); ok {
+				if model := apiErr.Model(); model != nil { // Extract UDR error
+					if pd, ok := model.(models.ProblemDetails); ok {
+						problemDetails = &pd // Use UDR provided cause
+					}
+				}
+			}
+			return nil, nil, problemDetails
+		}
+	}
+	// Close response body safely
 	defer func() {
 		if rspCloseErr := resp.Body.Close(); rspCloseErr != nil {
 			logger.UecmLog.Errorf("CreateSmfContextNon3gpp response body cannot close: %+v", rspCloseErr)
@@ -640,11 +722,11 @@ func RegistrationSmfRegistrationsProcedure(request *models.SmfRegistration, ueID
 	}()
 
 	if contextExisted {
-		return nil, nil, nil
-	} else {
-		header = make(http.Header)
-		udmUe, _ := udmContext.UDM_Self().UdmUeFindBySupi(ueID)
-		header.Set("Location", udmUe.GetLocationURI(udmContext.LocationUriSmfRegistration))
-		return header, request, nil
+		return nil, nil, nil // Return 204 No Content for updates
 	}
+	// Build 201 Created response
+	header = make(http.Header)
+	udmUe, _ := udmContext.UDM_Self().UdmUeFindBySupi(ueID)
+	header.Set("Location", udmUe.GetLocationURI(udmContext.LocationUriSmfRegistration))
+	return header, request, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**:
This PR corrects the Nudm_UECM SMF Registration procedure to align with 3GPP TS Spec. It ensures that roaming subscribers without a provisioned profile in the UDR are correctly rejected with a 403 Forbidden and the ROAMING_NOT_ALLOWED cause instead of an incorrect 404 or 500 error. Additionally, it fixes a protocol compliance issue where error responses were missing the mandatory application/problem+json Content-Type header. Safety checks were also added to prevent nil pointer panics during UDR communication.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#28 ](https://github.com/5GC-DEV/udm-cdac/issues/28)

**Test Report Added?**:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
NA
**Special notes for your reviewer**:
NIL